### PR TITLE
Move opentelemetry behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,16 @@ publish = ["wafflehacks"]
 [dependencies]
 eyre = "0.6"
 http = { version = "0.2", optional = true }
-opentelemetry = { version = "0.20", features = ["rt-tokio", "trace"] }
-opentelemetry-otlp = { version = "0.13", default-features = false, features = ["grpc-tonic", "http-proto", "reqwest-client", "reqwest-rustls", "tls", "tls-roots", "trace"] }
+opentelemetry = { version = "0.20", features = ["rt-tokio", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.13", default-features = false, features = ["grpc-tonic", "http-proto", "reqwest-client", "reqwest-rustls", "tls", "tls-roots", "trace"], optional = true }
 tower = { version = "0.4", default-features = false, optional = true }
 tower-http = { version = "0.4", default-features = false, features = ["trace"], optional = true }
 tracing = "0.1"
 tracing-error = "0.2"
-tracing-opentelemetry = { version = "0.21", default-features = false, features = ["tracing-log"] }
+tracing-opentelemetry = { version = "0.21", default-features = false, features = ["tracing-log"], optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"], optional = true }
 
 [features]
 http = ["dep:http", "dep:tower", "dep:tower-http", "dep:uuid"]
+opentelemetry = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -12,6 +12,13 @@ use opentelemetry::{
 use opentelemetry_otlp::{Protocol, SpanExporterBuilder, WithExportConfig};
 use std::time::Duration;
 
+/// Configuration for the exporter
+#[derive(Debug)]
+pub(crate) struct Config<'c> {
+    pub(crate) url: &'c str,
+    pub(crate) protocol: Protocol,
+}
+
 /// Create a new tracing pipeline
 pub(crate) fn tracer(exporter: SpanExporterBuilder) -> Result<Tracer, TraceError> {
     opentelemetry_otlp::new_pipeline()
@@ -22,17 +29,17 @@ pub(crate) fn tracer(exporter: SpanExporterBuilder) -> Result<Tracer, TraceError
 }
 
 /// Create a new span exporter depending on the protocol
-pub(crate) fn exporter(protocol: Protocol, url: &str) -> SpanExporterBuilder {
-    match protocol {
+pub(crate) fn exporter(config: Config<'_>) -> SpanExporterBuilder {
+    match config.protocol {
         Protocol::Grpc => opentelemetry_otlp::new_exporter()
             .tonic()
             .with_env()
-            .with_endpoint(url)
+            .with_endpoint(config.url)
             .into(),
         Protocol::HttpBinary => opentelemetry_otlp::new_exporter()
             .http()
             .with_env()
-            .with_endpoint(url)
+            .with_endpoint(config.url)
             .into(),
     }
 }


### PR DESCRIPTION
Moves OpenTelemetry exporting behind the `opentelemetry` feature. This reduces the library size for places where exporting traces is not necessary.