### PR TITLE
Re-export http layer at root level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,9 @@ pub mod http;
 #[cfg(feature = "opentelemetry")]
 mod otel;
 
+#[cfg(feature = "http")]
+pub use http::layer as http;
+
 /// Create a new logging configurator
 pub fn config() -> Builder<'static> {
     Builder::default()


### PR DESCRIPTION
Re-exports `http::layer` as `http` at the root of the crate for ease of use. Backward compatibility is not broken as the existing path is kept available.