### PR TITLE
Add graphql logging extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   default:
-    name: Library
+    name: Library (no features)
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -14,11 +14,18 @@ jobs:
 
       - run: cargo build --release
 
-  http:
-    name: Library (http)
+  feature:
+    name: Library (${{ matrix.feature }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - graphql
+          - http
+          - opentelemetry
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: cargo build --release -F http
+      - run: cargo build --release -F ${{ matrix.feature }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ publish = ["wafflehacks"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-graphql = { version = "6", default-features = false, optional = true }
+async-trait = { version = "0.1", optional = true }
 eyre = "0.6"
 http = { version = "0.2", optional = true }
 opentelemetry = { version = "0.20", features = ["rt-tokio", "trace"], optional = true }
@@ -24,5 +26,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"], optional = true }
 
 [features]
+graphql = ["dep:async-graphql", "dep:async-trait"]
 http = ["dep:http", "dep:tower", "dep:tower-http", "dep:uuid"]
 opentelemetry = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,0 +1,135 @@
+use async_graphql::{
+    extensions::{
+        Extension, ExtensionContext, ExtensionFactory, NextExecute, NextParseQuery, NextResolve,
+        NextValidation, ResolveInfo,
+    },
+    parser::types::{ExecutableDocument, OperationType, Selection},
+    Response, ServerError, ServerResult, ValidationResult, Value, Variables,
+};
+use std::{sync::Arc, time::Instant};
+use tracing::{debug, info, span, warn, Instrument, Level};
+
+/// Adds tracing to the GraphQL flow
+///
+/// Adapted from the [`async_graphql::extensions::Tracing`](https://docs.rs/async-graphql/latest/async_graphql/extensions/struct.Tracing.html)
+/// and [`async_graphql::extensions::Logger`](https://docs.rs/async-graphql/latest/async_graphql/extensions/struct.Logger.html)
+/// extensions.
+#[derive(Clone, Copy, Debug)]
+pub struct GraphQL;
+
+impl ExtensionFactory for GraphQL {
+    fn create(&self) -> Arc<dyn Extension> {
+        Arc::new(LoggingExtension)
+    }
+}
+
+struct LoggingExtension;
+
+#[async_trait::async_trait]
+impl Extension for LoggingExtension {
+    async fn parse_query(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        query: &str,
+        variables: &Variables,
+        next: NextParseQuery<'_>,
+    ) -> ServerResult<ExecutableDocument> {
+        let span = span!(Level::INFO, "parse");
+        let now = Instant::now();
+
+        async move {
+            debug!("started parsing request");
+            let result = next.run(ctx, query, variables).await;
+            debug!(
+                latency = format_args!("{} ms", now.elapsed().as_millis()),
+                "finished parsing request",
+            );
+
+            let document = result?;
+
+            let is_schema = document
+                .operations
+                .iter()
+                .filter(|(_, operation)| operation.node.ty == OperationType::Query)
+                .any(|(_, operation)| operation.node.selection_set.node.items.iter().any(|selection| matches!(&selection.node, Selection::Field(field) if field.node.name.node == "__schema")));
+            if !is_schema {
+                info!(document = ctx.stringify_execute_doc(&document, variables));
+            }
+
+            Ok(document)
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn validation(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        next: NextValidation<'_>,
+    ) -> async_graphql::Result<ValidationResult, Vec<ServerError>> {
+        let span = span!(Level::INFO, "validation");
+        next.run(ctx).instrument(span).await
+    }
+
+    async fn execute(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        operation_name: Option<&str>,
+        next: NextExecute<'_>,
+    ) -> Response {
+        let span = span!(Level::INFO, "execute", operation = %operation_name.unwrap_or_default());
+        let now = Instant::now();
+
+        async move {
+            debug!("started execution");
+            let response = next.run(ctx, operation_name).await;
+            debug!(
+                latency = format_args!("{} ms", now.elapsed().as_millis()),
+                "finished execution",
+            );
+
+            response
+        }
+        .instrument(span)
+        .await
+    }
+
+    async fn resolve(
+        &self,
+        ctx: &ExtensionContext<'_>,
+        info: ResolveInfo<'_>,
+        next: NextResolve<'_>,
+    ) -> ServerResult<Option<Value>> {
+        let path_node = info.path_node.to_string();
+        if path_node.starts_with("__schema") {
+            return next.run(ctx, info).await;
+        }
+
+        let span = span!(
+            Level::INFO, "field",
+            path = %path_node,
+            parent_type = %info.parent_type,
+            return_type = %info.return_type,
+        );
+        let now = Instant::now();
+
+        async move {
+            debug!("started resolution");
+            let result = next.run(ctx, info).await;
+            debug!(
+                latency = format_args!("{} ms", now.elapsed().as_millis()),
+                "finished resolution",
+            );
+
+            // we do the actual error handling elsewhere, these errors are typically caused by
+            // user error.
+            if let Err(ref err) = result {
+                warn!(error = %err.message, locations = ?err.locations, path = ?err.path);
+            }
+
+            result
+        }
+        .instrument(span)
+        .await
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,15 @@ use tracing_subscriber::{
 #[cfg(feature = "opentelemetry")]
 pub use opentelemetry_otlp::Protocol as OpenTelemetryProtocol;
 
+#[cfg(feature = "graphql")]
+mod graphql;
 #[cfg(feature = "http")]
 pub mod http;
 #[cfg(feature = "opentelemetry")]
 mod otel;
 
+#[cfg(feature = "graphql")]
+pub use graphql::GraphQL;
 #[cfg(feature = "http")]
 pub use http::layer as http;
 


### PR DESCRIPTION
Adds a logging extension for [`async-graphql`](https://docs.rs/async-graphql/latest/async_graphql/).