### PR TITLE
Use release-plz for automated release management

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,25 +5,37 @@ on:  # yamllint disable-line rule:truthy
   - push
 
 jobs:
-  default:
-    name: Library (no features)
+  generate-matrix:
+    name: Generate Build Matrix
     runs-on: ubuntu-22.04
+    outputs:
+      features: ${{ steps.generate-matrix.outputs.features }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Dasel
+        run: |
+          mkdir -p $HOME/.local/bin
+          DOWNLOAD_URL=$(gh api /repos/tomwright/dasel/releases/latest -q '.assets[] | select(.name == "dasel_linux_amd64") | .browser_download_url')
+          curl -sSLf $DOWNLOAD_URL -o $HOME/.local/bin/dasel
+          chmod +x $HOME/.local/bin/dasel
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-      - run: cargo build --release
+      - name: Generate matrix from Cargo features
+        id: generate-matrix
+        run: |
+          FEATURES=$(dasel -f Cargo.toml -w json --pretty=false '.features.keys()')
+          echo "features=$FEATURES" >> "$GITHUB_OUTPUT"
 
-  feature:
+  library:
     name: Library (${{ matrix.feature }})
     runs-on: ubuntu-22.04
+    needs: [generate-matrix]
     strategy:
       fail-fast: false
       matrix:
-        feature:
-          - graphql
-          - http
-          - opentelemetry
+        feature: ${{ fromJSON(needs.generate-matrix.outputs.features) }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,38 +3,32 @@ name: Publish
 
 on:  # yamllint disable-line rule:truthy
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
 
 jobs:
-  shipyard:
-    name: Shipyard
-    runs-on: ubuntu-22.04
+  release-plz:
+    name: Release Plz
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_PRIVATE_KEY }}
 
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+      - uses: TheHackerApp/setup-rust@main
         with:
           ssh-private-key: ${{ secrets.SHIPYARD_SSH_KEY }}
+          token: ${{ secrets.SHIPYARD_TOKEN }}
 
-      - name: Add shipyard host key to .ssh/known_hosts
-        run: |
-          mkdir -p ~/.ssh && touch ~/.ssh/known_hosts
-          ssh-keyscan ssh.shipyard.rs >> ~/.ssh/known_hosts
-
-      - name: Login to shipyard.rs
-        run: cargo login --registry wafflehacks ${{ secrets.SHIPYARD_TOKEN }}
-        env:
-          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
-      - run: cargo publish
-
-  release:
-    name: Release
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: softprops/action-gh-release@v1
+      - uses: MarcoIeni/release-plz-action@v0.5
         with:
-          generate_release_notes: true
+          registry: wafflehacks
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.SHIPYARD_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1", features = ["v4"], optional = true }
 
 [features]
+default = []
 graphql = ["dep:async-graphql", "dep:async-trait"]
 http = ["dep:http", "dep:tower", "dep:tower-http", "dep:uuid"]
 opentelemetry = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:tracing-opentelemetry"]


### PR DESCRIPTION
Switches to `release-plz` for automated release management. This removes the need to bump versions within a feature PR.

It also automates creating the build matrix for tests by parsing the features from `Cargo. tool`. This makes adding additional features less error-prone.