### PR TITLE
Revert to http 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,15 @@ publish = ["wafflehacks"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-graphql = { git = "https://github.com/TheHackerApp/async-graphql.git", branch = "axum-7", default-features = false, optional = true }
+async-graphql = { version = "6", default-features = false, optional = true }
 async-trait = { version = "0.1", optional = true }
 eyre = "0.6"
-http = { version = "1", optional = true }
+http = { version = "0.2", optional = true }
 opentelemetry = { version = "0.21", features = ["trace"], optional = true }
 opentelemetry-otlp = { version = "0.14", default-features = false, features = ["grpc-tonic", "http-proto", "reqwest-client", "reqwest-rustls", "tls", "tls-roots", "trace"], optional = true }
 opentelemetry_sdk = { version = "0.21", features = ["rt-tokio"], optional = true }
 tower = { version = "0.4", default-features = false, optional = true }
-tower-http = { version = "0.5", default-features = false, features = ["trace"], optional = true }
+tower-http = { version = "0.4", default-features = false, features = ["trace"], optional = true }
 tracing = "0.1"
 tracing-error = "0.2"
 tracing-opentelemetry = { version = "0.22", default-features = false, features = ["tracing-log"], optional = true }


### PR DESCRIPTION
Reverts the dependency bump of http, and by extension async-graphql and tower-http, back to 0.2 as the ecosystem has not yet fully updated to http 1.0.