### PR TITLE
Add OpenTelemetry W3C header propagation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { version = "0.1", optional = true }
 eyre = "0.6"
 http = { version = "0.2", optional = true }
 opentelemetry = { version = "0.21", features = ["trace"], optional = true }
+opentelemetry-http = { version = "0.10", optional = true }
 opentelemetry-otlp = { version = "0.14", default-features = false, features = ["grpc-tonic", "http-proto", "reqwest-client", "reqwest-rustls", "tls", "tls-roots", "trace"], optional = true }
 opentelemetry_sdk = { version = "0.21", features = ["rt-tokio"], optional = true }
 tower = { version = "0.4", default-features = false, optional = true }
@@ -30,4 +31,4 @@ uuid = { version = "1", features = ["v4"], optional = true }
 default = []
 graphql = ["dep:async-graphql", "dep:async-trait"]
 http = ["dep:http", "dep:tower", "dep:tower-http", "dep:uuid"]
-opentelemetry = ["dep:opentelemetry", "dep:opentelemetry-otlp", "dep:opentelemetry_sdk", "dep:tracing-opentelemetry"]
+opentelemetry = ["dep:opentelemetry", "dep:opentelemetry-http", "dep:opentelemetry-otlp", "dep:opentelemetry_sdk", "dep:tracing-opentelemetry"]

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,4 +1,6 @@
 use http::Request;
+#[cfg(feature = "opentelemetry")]
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tower_http::{
     classify::{ServerErrorsAsFailures, SharedClassifier},
     trace::{DefaultOnRequest, DefaultOnResponse, MakeSpan, TraceLayer},
@@ -7,26 +9,41 @@ use tracing::{span, Level, Span};
 use uuid::Uuid;
 
 /// Creates a custom tracing span
-#[derive(Clone, Copy, Debug)]
-pub struct MakeSpanWithId;
+#[derive(Clone, Debug, Default)]
+pub struct MakeSpanWithId {
+    #[cfg(feature = "opentelemetry")]
+    propagator: TraceContextPropagator,
+}
 
 impl<B> MakeSpan<B> for MakeSpanWithId {
     fn make_span(&mut self, request: &Request<B>) -> Span {
-        span!(
+        let span = span!(
             Level::INFO,
             "request",
             method = %request.method(),
             uri = %request.uri(),
             version = ?request.version(),
             id = %Uuid::new_v4(),
-        )
+        );
+
+        #[cfg(feature = "opentelemetry")]
+        {
+            use opentelemetry::propagation::TextMapPropagator;
+            use opentelemetry_http::HeaderExtractor;
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+            let context = self.propagator.extract(&HeaderExtractor(request.headers()));
+            span.set_parent(context);
+        }
+
+        span
     }
 }
 
 /// Create a logging middleware layer
 pub fn layer() -> TraceLayer<SharedClassifier<ServerErrorsAsFailures>, MakeSpanWithId> {
     TraceLayer::new_for_http()
-        .make_span_with(MakeSpanWithId)
+        .make_span_with(MakeSpanWithId::default())
         .on_request(DefaultOnRequest::new().level(Level::INFO))
         .on_response(DefaultOnResponse::new().level(Level::INFO))
 }


### PR DESCRIPTION
Adds support for OpenTelemetry propagation via the [W3C Trace Context](https://www.w3.org/TR/trace-context/). This will allow traces to be associated with each other across services.