### PR TITLE
Use feature powerset for CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,32 +12,23 @@ jobs:
       features: ${{ steps.generate-matrix.outputs.features }}
     steps:
       - uses: actions/checkout@v4
-      - name: Install Dasel
-        run: |
-          mkdir -p $HOME/.local/bin
-          DOWNLOAD_URL=$(gh api /repos/tomwright/dasel/releases/latest -q '.assets[] | select(.name == "dasel_linux_amd64") | .browser_download_url')
-          curl -sSLf $DOWNLOAD_URL -o $HOME/.local/bin/dasel
-          chmod +x $HOME/.local/bin/dasel
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-      - name: Generate matrix from Cargo features
+      - run: python3 ./tools/features.py
         id: generate-matrix
-        run: |
-          FEATURES=$(dasel -f Cargo.toml -w json --pretty=false '.features.keys()')
-          echo "features=$FEATURES" >> "$GITHUB_OUTPUT"
 
   library:
-    name: Library (${{ matrix.feature }})
+    name: Library (${{ matrix.features }})
     runs-on: ubuntu-22.04
     needs: [generate-matrix]
     strategy:
       fail-fast: false
       matrix:
-        feature: ${{ fromJSON(needs.generate-matrix.outputs.features) }}
+        features: ${{ fromJSON(needs.generate-matrix.outputs.features) }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: cargo build --release -F ${{ matrix.feature }}
+      - run: cargo build --release -F "${{ matrix.features }}"

--- a/tools/features.py
+++ b/tools/features.py
@@ -1,0 +1,19 @@
+import json
+import tomllib
+from itertools import chain, combinations
+from os import environ
+from pathlib import Path
+
+cargo_toml = Path.cwd() / "Cargo.toml"
+manifest = tomllib.load(cargo_toml.open("rb"))
+
+features = manifest.get("features", {}).keys()
+features_powerset = list(chain.from_iterable(combinations(features, r) for r in range(len(features)+1)))
+
+result = json.dumps([','.join(feature_set) for feature_set in features_powerset])
+
+if (path := environ.get("GITHUB_OUTPUT")) is not None:
+    with open(path, "a") as output:
+        output.write(f"features={result}\n")
+else:
+    print(result)


### PR DESCRIPTION
Switch to using a powerset of the crate's features for building to ensure everything works with everything else.

The matrix elements are generated using a simply Python script that reads the `features` from the Cargo manifest. The output is written to a GitHub output as a JSON array, but if the `GITHUB_OUTPUT` environment variable is set.